### PR TITLE
Save and load block data using IPFS

### DIFF
--- a/blockchain/v0/reactor.go
+++ b/blockchain/v0/reactor.go
@@ -181,7 +181,6 @@ func (bcR *BlockchainReactor) respondToPeer(msg *bcproto.BlockRequest,
 
 	block, err := bcR.store.LoadBlock(context.TODO(), msg.Height)
 	if err != nil {
-		// todo(evan): handle this error
 		panic(err)
 	}
 	if block != nil {
@@ -425,7 +424,7 @@ FOR_LOOP:
 				// TODO: batch saves so we dont persist to disk every block
 				err := bcR.store.SaveBlock(context.TODO(), first, firstParts, second.LastCommit)
 				if err != nil {
-					// todo(evan): don't panic
+					// an error is only returned if something with the local IPFS blockstore is seriously wrong
 					panic(err)
 				}
 

--- a/blockchain/v0/reactor.go
+++ b/blockchain/v0/reactor.go
@@ -1,6 +1,7 @@
 package v0
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"time"
@@ -178,7 +179,11 @@ func (bcR *BlockchainReactor) RemovePeer(peer p2p.Peer, reason interface{}) {
 func (bcR *BlockchainReactor) respondToPeer(msg *bcproto.BlockRequest,
 	src p2p.Peer) (queued bool) {
 
-	block := bcR.store.LoadBlock(msg.Height)
+	block, err := bcR.store.LoadBlock(context.TODO(), msg.Height)
+	if err != nil {
+		// todo(evan): handle this error
+		panic(err)
+	}
 	if block != nil {
 		bl, err := block.ToProto()
 		if err != nil {
@@ -418,11 +423,14 @@ FOR_LOOP:
 				bcR.pool.PopRequest()
 
 				// TODO: batch saves so we dont persist to disk every block
-				bcR.store.SaveBlock(first, firstParts, second.LastCommit)
+				err := bcR.store.SaveBlock(context.TODO(), first, firstParts, second.LastCommit)
+				if err != nil {
+					// todo(evan): don't panic
+					panic(err)
+				}
 
 				// TODO: same thing for app - but we would need a way to get the hash
 				// without persisting the state.
-				var err error
 				state, _, err = bcR.blockExec.ApplyBlock(state, firstID, first)
 				if err != nil {
 					// TODO This is bad, are we zombie?

--- a/blockchain/v0/reactor_test.go
+++ b/blockchain/v0/reactor_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	mdutils "github.com/ipfs/go-merkledag/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -70,10 +69,9 @@ func newBlockchainReactor(
 		panic(fmt.Errorf("error start app: %w", err))
 	}
 
-	blockDB := memdb.NewDB()
 	stateDB := memdb.NewDB()
 	stateStore := sm.NewStore(stateDB)
-	blockStore := store.NewBlockStore(blockDB, mdutils.Mock())
+	blockStore := store.MockBlockStore(nil)
 
 	state, err := stateStore.LoadFromDBOrGenesisDoc(genDoc)
 	if err != nil {

--- a/blockchain/v0/reactor_test.go
+++ b/blockchain/v0/reactor_test.go
@@ -1,6 +1,7 @@
 package v0
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"os"
@@ -100,7 +101,10 @@ func newBlockchainReactor(
 		lastCommit := types.NewCommit(blockHeight-1, 0, types.BlockID{}, nil)
 		if blockHeight > 1 {
 			lastBlockMeta := blockStore.LoadBlockMeta(blockHeight - 1)
-			lastBlock := blockStore.LoadBlock(blockHeight - 1)
+			lastBlock, err := blockStore.LoadBlock(context.TODO(), blockHeight-1)
+			if err != nil {
+				panic(err)
+			}
 
 			vote, err := types.MakeVote(
 				lastBlock.Header.Height,
@@ -127,7 +131,10 @@ func newBlockchainReactor(
 			panic(fmt.Errorf("error apply block: %w", err))
 		}
 
-		blockStore.SaveBlock(thisBlock, thisParts, lastCommit)
+		err := blockStore.SaveBlock(context.TODO(), thisBlock, thisParts, lastCommit)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	bcReactor := NewBlockchainReactor(state.Copy(), blockExec, blockStore, fastSync)
@@ -184,7 +191,10 @@ func TestNoBlockResponse(t *testing.T) {
 	assert.Equal(t, maxBlockHeight, reactorPairs[0].reactor.store.Height())
 
 	for _, tt := range tests {
-		block := reactorPairs[1].reactor.store.LoadBlock(tt.height)
+		block, err := reactorPairs[1].reactor.store.LoadBlock(context.TODO(), tt.height)
+		if err != nil {
+			panic(err)
+		}
 		if tt.existent {
 			assert.True(t, block != nil)
 		} else {

--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -56,9 +56,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 		vals := types.TM2PB.ValidatorUpdates(state.Validators)
 		app.InitChain(abci.RequestInitChain{Validators: vals})
 
-		blockDB := memdb.NewDB()
-		dag := mdutils.Mock()
-		blockStore := store.NewBlockStore(blockDB, dag)
+		blockStore := store.MockBlockStore(nil)
 
 		// one for mempool, one for consensus
 		mtx := new(tmsync.Mutex)
@@ -81,7 +79,7 @@ func TestByzantinePrevoteEquivocation(t *testing.T) {
 		// Make State
 		blockExec := sm.NewBlockExecutor(stateStore, log.TestingLogger(), proxyAppConnCon, mempool, evpool)
 		cs := NewState(thisConfig.Consensus, state, blockExec, blockStore,
-			mempool, dag, ipfs.MockRouting(), evpool)
+			mempool, mdutils.Mock(), ipfs.MockRouting(), evpool)
 		cs.SetLogger(cs.Logger)
 		// set private validator
 		pv := privVals[i]

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -14,7 +14,10 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log/term"
+	"github.com/ipfs/go-blockservice"
+	offline "github.com/ipfs/go-ipfs-exchange-offline"
 	format "github.com/ipfs/go-ipld-format"
+	"github.com/ipfs/go-merkledag"
 	mdutils "github.com/ipfs/go-merkledag/test"
 	"github.com/stretchr/testify/require"
 
@@ -356,7 +359,7 @@ func subscribeToVoter(cs *State, addr []byte) <-chan tmpubsub.Message {
 
 func newState(state sm.State, pv types.PrivValidator, app abci.Application, ipfsDagAPI format.DAGService) *State {
 	config := cfg.ResetTestRoot("consensus_state_test")
-	return newStateWithConfig(config, state, pv, app, ipfsDagAPI)
+	return newStateWithConfig(config, state, pv, app)
 }
 
 func newStateWithConfig(
@@ -364,10 +367,9 @@ func newStateWithConfig(
 	state sm.State,
 	pv types.PrivValidator,
 	app abci.Application,
-	ipfsDagAPI format.DAGService,
 ) *State {
 	blockDB := memdb.NewDB()
-	return newStateWithConfigAndBlockStore(thisConfig, state, pv, app, blockDB, ipfsDagAPI)
+	return newStateWithConfigAndBlockStore(thisConfig, state, pv, app, blockDB)
 }
 
 func newStateWithConfigAndBlockStore(
@@ -376,10 +378,11 @@ func newStateWithConfigAndBlockStore(
 	pv types.PrivValidator,
 	app abci.Application,
 	blockDB dbm.DB,
-	dag format.DAGService,
 ) *State {
 	// Get BlockStore
-	blockStore := store.MockBlockStore(blockDB)
+	bs := ipfs.MockBlockStore()
+	dag := merkledag.NewDAGService(blockservice.New(bs, offline.Exchange(bs)))
+	blockStore := store.NewBlockStore(blockDB, bs, log.TestingLogger())
 
 	// one for mempool, one for consensus
 	mtx := new(tmsync.Mutex)
@@ -708,7 +711,7 @@ func randConsensusNet(
 		vals := types.TM2PB.ValidatorUpdates(state.Validators)
 		app.InitChain(abci.RequestInitChain{Validators: vals})
 
-		css[i] = newStateWithConfigAndBlockStore(thisConfig, state, privVals[i], app, stateDB, mdutils.Mock())
+		css[i] = newStateWithConfigAndBlockStore(thisConfig, state, privVals[i], app, stateDB)
 		css[i].SetTimeoutTicker(tickerFunc())
 		css[i].SetLogger(logger.With("validator", i, "module", "consensus"))
 	}
@@ -771,7 +774,7 @@ func randConsensusNetWithPeers(
 		app.InitChain(abci.RequestInitChain{Validators: vals})
 		// sm.SaveState(stateDB,state)	//height 1's validatorsInfo already saved in LoadStateFromDBOrGenesisDoc above
 
-		css[i] = newStateWithConfig(thisConfig, state, privVal, app, mdutils.Mock())
+		css[i] = newStateWithConfig(thisConfig, state, privVal, app)
 		css[i].SetTimeoutTicker(tickerFunc())
 		css[i].SetLogger(logger.With("validator", i, "module", "consensus"))
 	}

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -379,7 +379,7 @@ func newStateWithConfigAndBlockStore(
 	dag format.DAGService,
 ) *State {
 	// Get BlockStore
-	blockStore := store.NewBlockStore(blockDB, dag)
+	blockStore := store.MockBlockStore(blockDB)
 
 	// one for mempool, one for consensus
 	mtx := new(tmsync.Mutex)

--- a/consensus/mempool_test.go
+++ b/consensus/mempool_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	mdutils "github.com/ipfs/go-merkledag/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -30,7 +29,7 @@ func TestMempoolNoProgressUntilTxsAvailable(t *testing.T) {
 
 	config.Consensus.CreateEmptyBlocks = false
 	state, privVals := randGenesisState(1, false, 10)
-	cs := newStateWithConfig(config, state, privVals[0], NewCounterApplication(), mdutils.Mock())
+	cs := newStateWithConfig(config, state, privVals[0], NewCounterApplication())
 	assertMempool(cs.txNotifier).EnableTxsAvailable()
 	height, round := cs.Height, cs.Round
 	newBlockCh := subscribe(cs.eventBus, types.EventQueryNewBlock)
@@ -50,7 +49,7 @@ func TestMempoolProgressAfterCreateEmptyBlocksInterval(t *testing.T) {
 
 	config.Consensus.CreateEmptyBlocksInterval = ensureTimeout
 	state, privVals := randGenesisState(1, false, 10)
-	cs := newStateWithConfig(config, state, privVals[0], NewCounterApplication(), mdutils.Mock())
+	cs := newStateWithConfig(config, state, privVals[0], NewCounterApplication())
 
 	assertMempool(cs.txNotifier).EnableTxsAvailable()
 
@@ -68,7 +67,7 @@ func TestMempoolProgressInHigherRound(t *testing.T) {
 
 	config.Consensus.CreateEmptyBlocks = false
 	state, privVals := randGenesisState(1, false, 10)
-	cs := newStateWithConfig(config, state, privVals[0], NewCounterApplication(), mdutils.Mock())
+	cs := newStateWithConfig(config, state, privVals[0], NewCounterApplication())
 
 	assertMempool(cs.txNotifier).EnableTxsAvailable()
 	height, round := cs.Height, cs.Round
@@ -118,7 +117,7 @@ func TestMempoolTxConcurrentWithCommit(t *testing.T) {
 	blockDB := memdb.NewDB()
 	stateStore := sm.NewStore(blockDB)
 
-	cs := newStateWithConfigAndBlockStore(config, state, privVals[0], NewCounterApplication(), blockDB, mdutils.Mock())
+	cs := newStateWithConfigAndBlockStore(config, state, privVals[0], NewCounterApplication(), blockDB)
 	err := stateStore.Save(state)
 	require.NoError(t, err)
 	newBlockHeaderCh := subscribe(cs.eventBus, types.EventQueryNewBlockHeader)
@@ -144,7 +143,7 @@ func TestMempoolRmBadTx(t *testing.T) {
 	blockDB := memdb.NewDB()
 
 	stateStore := sm.NewStore(blockDB)
-	cs := newStateWithConfigAndBlockStore(config, state, privVals[0], app, blockDB, mdutils.Mock())
+	cs := newStateWithConfigAndBlockStore(config, state, privVals[0], app, blockDB)
 	err := stateStore.Save(state)
 	require.NoError(t, err)
 

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -155,10 +155,8 @@ func TestReactorWithEvidence(t *testing.T) {
 		// duplicate code from:
 		// css[i] = newStateWithConfig(thisConfig, state, privVals[i], app)
 
-		blockDB := memdb.NewDB()
 		dag := mdutils.Mock()
-		blockStore := store.NewBlockStore(blockDB, dag)
-
+		blockStore := store.MockBlockStore(nil)
 		// one for mempool, one for consensus
 		mtx := new(tmsync.Mutex)
 		proxyAppConnMem := abcicli.NewLocalClient(mtx, app)

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -463,7 +463,11 @@ func (h *Handshaker) replayBlocks(
 	}
 	for i := firstBlock; i <= finalBlock; i++ {
 		h.logger.Info("Applying block", "height", i)
-		block := h.store.LoadBlock(i)
+		block, err := h.store.LoadBlock(context.TODO(), i)
+		if err != nil {
+			// todo(evan): handle error
+			panic(err)
+		}
 		// Extra check to ensure the app was not changed in a way it shouldn't have.
 		if len(appHash) > 0 {
 			assertAppHashEqualsOneFromBlock(appHash, block)
@@ -492,7 +496,12 @@ func (h *Handshaker) replayBlocks(
 
 // ApplyBlock on the proxyApp with the last block.
 func (h *Handshaker) replayBlock(state sm.State, height int64, proxyApp proxy.AppConnConsensus) (sm.State, error) {
-	block := h.store.LoadBlock(height)
+	block, err := h.store.LoadBlock(context.TODO(), height)
+	if err != nil {
+		// todo(evan): handle/bubble this error
+		panic(err)
+		// return sm.State{}, err
+	}
 	meta := h.store.LoadBlockMeta(height)
 
 	// Use stubs for both mempool and evidence pool since no transactions nor
@@ -500,7 +509,6 @@ func (h *Handshaker) replayBlock(state sm.State, height int64, proxyApp proxy.Ap
 	blockExec := sm.NewBlockExecutor(h.stateStore, h.logger, proxyApp, emptyMempool{}, sm.EmptyEvidencePool{})
 	blockExec.SetEventBus(h.eventBus)
 
-	var err error
 	state, _, err = blockExec.ApplyBlock(state, meta.BlockID, block)
 	if err != nil {
 		return sm.State{}, err

--- a/consensus/replay.go
+++ b/consensus/replay.go
@@ -465,8 +465,7 @@ func (h *Handshaker) replayBlocks(
 		h.logger.Info("Applying block", "height", i)
 		block, err := h.store.LoadBlock(context.TODO(), i)
 		if err != nil {
-			// todo(evan): handle error
-			panic(err)
+			return nil, err
 		}
 		// Extra check to ensure the app was not changed in a way it shouldn't have.
 		if len(appHash) > 0 {
@@ -498,9 +497,7 @@ func (h *Handshaker) replayBlocks(
 func (h *Handshaker) replayBlock(state sm.State, height int64, proxyApp proxy.AppConnConsensus) (sm.State, error) {
 	block, err := h.store.LoadBlock(context.TODO(), height)
 	if err != nil {
-		// todo(evan): handle/bubble this error
-		panic(err)
-		// return sm.State{}, err
+		return sm.State{}, err
 	}
 	meta := h.store.LoadBlockMeta(height)
 

--- a/consensus/replay_file.go
+++ b/consensus/replay_file.go
@@ -291,7 +291,7 @@ func newConsensusStateForReplay(config cfg.BaseConfig, csConfig *cfg.ConsensusCo
 		tmos.Exit(err.Error())
 	}
 	dag := mdutils.Mock()
-	blockStore := store.NewBlockStore(blockStoreDB, dag)
+	blockStore := store.MockBlockStore(blockStoreDB)
 
 	// Get State
 	stateDB, err := badgerdb.NewDB("state", config.DBDir())

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -79,7 +79,6 @@ func startNewStateAndWaitForBlock(t *testing.T, consensusReplayConfig *cfg.Confi
 		privValidator,
 		kvstore.NewApplication(),
 		blockDB,
-		mdutils.Mock(),
 	)
 	cs.SetLogger(logger)
 
@@ -174,7 +173,6 @@ LOOP:
 			privValidator,
 			kvstore.NewApplication(),
 			blockDB,
-			mdutils.Mock(),
 		)
 		cs.SetLogger(logger)
 
@@ -1215,7 +1213,12 @@ func (bs *mockBlockStore) LoadBlockMeta(height int64) *types.BlockMeta {
 	}
 }
 func (bs *mockBlockStore) LoadBlockPart(height int64, index int) *types.Part { return nil }
-func (bs *mockBlockStore) SaveBlock(ctx context.Context, block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit) error {
+func (bs *mockBlockStore) SaveBlock(
+	ctx context.Context,
+	block *types.Block,
+	blockParts *types.PartSet,
+	seenCommit *types.Commit,
+) error {
 	return nil
 }
 func (bs *mockBlockStore) LoadBlockCommit(height int64) *types.Commit {

--- a/consensus/replay_test.go
+++ b/consensus/replay_test.go
@@ -548,7 +548,9 @@ func TestSimulateValidatorsChange(t *testing.T) {
 	sim.Chain = make([]*types.Block, 0)
 	sim.Commits = make([]*types.Commit, 0)
 	for i := 1; i <= numBlocks; i++ {
-		sim.Chain = append(sim.Chain, css[0].blockStore.LoadBlock(int64(i)))
+		blck, err := css[0].blockStore.LoadBlock(context.TODO(), int64(i))
+		require.NoError(t, err)
+		sim.Chain = append(sim.Chain, blck)
 		sim.Commits = append(sim.Commits, css[0].blockStore.LoadBlockCommit(int64(i)))
 	}
 }
@@ -1195,13 +1197,15 @@ func newMockBlockStore(config *cfg.Config, params tmproto.ConsensusParams) *mock
 	return &mockBlockStore{config, params, nil, nil, 0, mdutils.Mock()}
 }
 
-func (bs *mockBlockStore) Height() int64                       { return int64(len(bs.chain)) }
-func (bs *mockBlockStore) Base() int64                         { return bs.base }
-func (bs *mockBlockStore) Size() int64                         { return bs.Height() - bs.Base() + 1 }
-func (bs *mockBlockStore) LoadBaseMeta() *types.BlockMeta      { return bs.LoadBlockMeta(bs.base) }
-func (bs *mockBlockStore) LoadBlock(height int64) *types.Block { return bs.chain[height-1] }
-func (bs *mockBlockStore) LoadBlockByHash(hash []byte) *types.Block {
-	return bs.chain[int64(len(bs.chain))-1]
+func (bs *mockBlockStore) Height() int64                  { return int64(len(bs.chain)) }
+func (bs *mockBlockStore) Base() int64                    { return bs.base }
+func (bs *mockBlockStore) Size() int64                    { return bs.Height() - bs.Base() + 1 }
+func (bs *mockBlockStore) LoadBaseMeta() *types.BlockMeta { return bs.LoadBlockMeta(bs.base) }
+func (bs *mockBlockStore) LoadBlock(ctx context.Context, height int64) (*types.Block, error) {
+	return bs.chain[height-1], nil
+}
+func (bs *mockBlockStore) LoadBlockByHash(ctx context.Context, hash []byte) (*types.Block, error) {
+	return bs.chain[int64(len(bs.chain))-1], nil
 }
 func (bs *mockBlockStore) LoadBlockMeta(height int64) *types.BlockMeta {
 	block := bs.chain[height-1]
@@ -1211,7 +1215,8 @@ func (bs *mockBlockStore) LoadBlockMeta(height int64) *types.BlockMeta {
 	}
 }
 func (bs *mockBlockStore) LoadBlockPart(height int64, index int) *types.Part { return nil }
-func (bs *mockBlockStore) SaveBlock(block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit) {
+func (bs *mockBlockStore) SaveBlock(ctx context.Context, block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit) error {
+	return nil
 }
 func (bs *mockBlockStore) LoadBlockCommit(height int64) *types.Commit {
 	return bs.commits[height-1]

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1139,7 +1139,7 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 		// the provide timeout could still be larger than just the time between
 		// two consecutive proposals.
 		//
-		// cs.proposalCancel()
+		cs.proposalCancel()
 	}
 	cs.proposalCtx, cs.proposalCancel = context.WithCancel(context.TODO())
 	go func(ctx context.Context) {
@@ -1585,7 +1585,7 @@ func (cs *State) finalizeCommit(height int64) {
 		// but may differ from the LastCommit included in the next block
 		precommits := cs.Votes.Precommits(cs.CommitRound)
 		seenCommit := precommits.MakeCommit()
-		err := cs.blockStore.SaveBlock(cs.proposalCtx, block, blockParts, seenCommit)
+		err := cs.blockStore.SaveBlock(context.TODO(), block, blockParts, seenCommit)
 		if err != nil {
 			panic(err)
 		}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1122,7 +1122,7 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 	}
 
 	// cancel ctx for previous proposal block to ensure block putting/providing does not queues up
-	if cs.proposalCancel != nil { //nolint:staticcheck
+	if cs.proposalCancel != nil {
 		// FIXME(ismail): below commented out cancel tries to prevent block putting
 		// and providing no to queue up endlessly.
 		// But in a real network proposers should have enough time in between.

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -1585,7 +1585,10 @@ func (cs *State) finalizeCommit(height int64) {
 		// but may differ from the LastCommit included in the next block
 		precommits := cs.Votes.Precommits(cs.CommitRound)
 		seenCommit := precommits.MakeCommit()
-		cs.blockStore.SaveBlock(block, blockParts, seenCommit)
+		err := cs.blockStore.SaveBlock(cs.proposalCtx, block, blockParts, seenCommit)
+		if err != nil {
+			panic(err)
+		}
 	} else {
 		// Happens during replay if we already saved the block but didn't commit
 		cs.Logger.Info("Calling finalizeCommit on already stored block", "height", block.Height)

--- a/consensus/wal_test.go
+++ b/consensus/wal_test.go
@@ -311,7 +311,7 @@ func walGenerateNBlocks(t *testing.T, wr io.Writer, numBlocks int) (err error) {
 		t.Error(err)
 	}
 	dag := mdutils.Mock()
-	blockStore := store.NewBlockStore(blockStoreDB, dag)
+	blockStore := store.MockBlockStore(blockStoreDB)
 
 	proxyApp := proxy.NewAppConns(proxy.NewLocalClientCreator(app))
 	proxyApp.SetLogger(logger.With("module", "proxy"))

--- a/evidence/pool_test.go
+++ b/evidence/pool_test.go
@@ -1,6 +1,7 @@
 package evidence_test
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -408,7 +409,10 @@ func initializeBlockStore(db dbm.DB, state sm.State, valAddr []byte) *store.Bloc
 		partSet := block.MakePartSet(parts)
 
 		seenCommit := makeCommit(i, valAddr)
-		blockStore.SaveBlock(block, partSet, seenCommit)
+		err := blockStore.SaveBlock(context.TODO(), block, partSet, seenCommit)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	return blockStore

--- a/evidence/pool_test.go
+++ b/evidence/pool_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	mdutils "github.com/ipfs/go-merkledag/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -397,7 +396,7 @@ func initializeValidatorState(privVal types.PrivValidator, height int64) sm.Stor
 // initializeBlockStore creates a block storage and populates it w/ a dummy
 // block at +height+.
 func initializeBlockStore(db dbm.DB, state sm.State, valAddr []byte) *store.BlockStore {
-	blockStore := store.NewBlockStore(db, mdutils.Mock())
+	blockStore := store.MockBlockStore(db)
 
 	for i := int64(1); i <= state.LastBlockHeight; i++ {
 		lastCommit := makeCommit(i-1, valAddr)

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/ipfs/go-ipfs-api v0.2.0
 	github.com/ipfs/go-ipfs-blockstore v0.1.4
 	github.com/ipfs/go-ipfs-config v0.11.0
+	github.com/ipfs/go-ipfs-exchange-offline v0.0.1
 	github.com/ipfs/go-ipfs-routing v0.1.0
 	github.com/ipfs/go-ipld-format v0.2.0
 	github.com/ipfs/go-merkledag v0.3.2

--- a/ipfs/mock.go
+++ b/ipfs/mock.go
@@ -3,6 +3,9 @@ package ipfs
 import (
 	"context"
 
+	ds "github.com/ipfs/go-datastore"
+	ds_sync "github.com/ipfs/go-datastore/sync"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	nilrouting "github.com/ipfs/go-ipfs-routing/none"
 	"github.com/ipfs/go-ipfs/core"
 	coremock "github.com/ipfs/go-ipfs/core/mock"
@@ -42,4 +45,8 @@ func MockNode() (*core.IpfsNode, error) {
 func MockRouting() routing.Routing {
 	croute, _ := nilrouting.ConstructNilRouting(context.TODO(), nil, nil, nil)
 	return croute
+}
+
+func MockBlockStore() blockstore.Blockstore {
+	return blockstore.NewBlockstore(ds_sync.MutexWrap(ds.NewMapDatastore()))
 }

--- a/node/node.go
+++ b/node/node.go
@@ -690,7 +690,7 @@ func NewNode(config *cfg.Config,
 		return nil, err
 	}
 
-	blockStore := store.NewBlockStore(blockStoreDB, ipfsNode.DAG)
+	blockStore := store.NewBlockStore(blockStoreDB, ipfsNode.Blockstore, logger)
 
 	// Create the handshaker, which calls RequestInfo, sets the AppVersion on the state,
 	// and replays any blocks as necessary to sync tendermint with the app.

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	mdutils "github.com/ipfs/go-merkledag/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -284,7 +283,7 @@ func TestCreateProposalBlock(t *testing.T) {
 
 	// Make EvidencePool
 	evidenceDB := memdb.NewDB()
-	blockStore := store.NewBlockStore(memdb.NewDB(), mdutils.Mock())
+	blockStore := store.MockBlockStore(nil)
 	evidencePool, err := evidence.NewPool(evidenceDB, stateStore, blockStore)
 	require.NoError(t, err)
 	evidencePool.SetLogger(logger)

--- a/rpc/core/blocks.go
+++ b/rpc/core/blocks.go
@@ -89,7 +89,10 @@ func Block(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultBlock, error)
 		return nil, err
 	}
 
-	block := env.BlockStore.LoadBlock(height)
+	block, err := env.BlockStore.LoadBlock(ctx.Context(), height)
+	if err != nil {
+		return &ctypes.ResultBlock{BlockID: types.BlockID{}, Block: block}, err
+	}
 	blockMeta := env.BlockStore.LoadBlockMeta(height)
 	if blockMeta == nil {
 		return &ctypes.ResultBlock{BlockID: types.BlockID{}, Block: block}, nil
@@ -100,7 +103,10 @@ func Block(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.ResultBlock, error)
 // BlockByHash gets block by hash.
 // More: https://docs.tendermint.com/master/rpc/#/Info/block_by_hash
 func BlockByHash(ctx *rpctypes.Context, hash []byte) (*ctypes.ResultBlock, error) {
-	block := env.BlockStore.LoadBlockByHash(hash)
+	block, err := env.BlockStore.LoadBlockByHash(ctx.Context(), hash)
+	if err != nil {
+		return &ctypes.ResultBlock{BlockID: types.BlockID{}, Block: nil}, err
+	}
 	if block == nil {
 		return &ctypes.ResultBlock{BlockID: types.BlockID{}, Block: nil}, nil
 	}
@@ -147,7 +153,12 @@ func DataAvailabilityHeader(ctx *rpctypes.Context, heightPtr *int64) (*ctypes.Re
 	// depends on either:
 	// - https://github.com/lazyledger/lazyledger-core/pull/312, or
 	// - https://github.com/lazyledger/lazyledger-core/pull/218
-	block := env.BlockStore.LoadBlock(height)
+	block, err := env.BlockStore.LoadBlock(ctx.Context(), height)
+	if err != nil {
+		return &ctypes.ResultDataAvailabilityHeader{
+			DataAvailabilityHeader: types.DataAvailabilityHeader{},
+		}, err
+	}
 	_ = block.Hash()
 	dah := block.DataAvailabilityHeader
 	return &ctypes.ResultDataAvailabilityHeader{

--- a/rpc/core/blocks_test.go
+++ b/rpc/core/blocks_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -118,16 +119,21 @@ type mockBlockStore struct {
 	height int64
 }
 
-func (mockBlockStore) Base() int64                                       { return 1 }
-func (store mockBlockStore) Height() int64                               { return store.height }
-func (store mockBlockStore) Size() int64                                 { return store.height }
-func (mockBlockStore) LoadBaseMeta() *types.BlockMeta                    { return nil }
-func (mockBlockStore) LoadBlockMeta(height int64) *types.BlockMeta       { return nil }
-func (mockBlockStore) LoadBlock(height int64) *types.Block               { return nil }
-func (mockBlockStore) LoadBlockByHash(hash []byte) *types.Block          { return nil }
+func (mockBlockStore) Base() int64                                 { return 1 }
+func (store mockBlockStore) Height() int64                         { return store.height }
+func (store mockBlockStore) Size() int64                           { return store.height }
+func (mockBlockStore) LoadBaseMeta() *types.BlockMeta              { return nil }
+func (mockBlockStore) LoadBlockMeta(height int64) *types.BlockMeta { return nil }
+func (mockBlockStore) LoadBlock(ctx context.Context, height int64) (*types.Block, error) {
+	return nil, nil
+}
+func (mockBlockStore) LoadBlockByHash(ctx context.Context, hash []byte) (*types.Block, error) {
+	return nil, nil
+}
 func (mockBlockStore) LoadBlockPart(height int64, index int) *types.Part { return nil }
 func (mockBlockStore) LoadBlockCommit(height int64) *types.Commit        { return nil }
 func (mockBlockStore) LoadSeenCommit(height int64) *types.Commit         { return nil }
 func (mockBlockStore) PruneBlocks(height int64) (uint64, error)          { return 0, nil }
-func (mockBlockStore) SaveBlock(block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit) {
+func (mockBlockStore) SaveBlock(ctx context.Context, block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit) error {
+	return nil
 }

--- a/rpc/core/blocks_test.go
+++ b/rpc/core/blocks_test.go
@@ -134,6 +134,11 @@ func (mockBlockStore) LoadBlockPart(height int64, index int) *types.Part { retur
 func (mockBlockStore) LoadBlockCommit(height int64) *types.Commit        { return nil }
 func (mockBlockStore) LoadSeenCommit(height int64) *types.Commit         { return nil }
 func (mockBlockStore) PruneBlocks(height int64) (uint64, error)          { return 0, nil }
-func (mockBlockStore) SaveBlock(ctx context.Context, block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit) error {
+func (mockBlockStore) SaveBlock(
+	ctx context.Context,
+	block *types.Block,
+	blockParts *types.PartSet,
+	seenCommit *types.Commit,
+) error {
 	return nil
 }

--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -38,7 +38,9 @@ func Tx(ctx *rpctypes.Context, hash []byte, prove bool) (*ctypes.ResultTx, error
 	var proof types.TxProof
 	if prove {
 		block, err := env.BlockStore.LoadBlock(ctx.Context(), height)
-		return nil, fmt.Errorf("tx (%X) not found: %w", hash, err)
+		if err != nil {
+			return nil, err
+		}
 		proof = block.Data.Txs.Proof(int(index)) // XXX: overflow on 32-bit machines
 	}
 

--- a/rpc/core/tx.go
+++ b/rpc/core/tx.go
@@ -37,7 +37,8 @@ func Tx(ctx *rpctypes.Context, hash []byte, prove bool) (*ctypes.ResultTx, error
 
 	var proof types.TxProof
 	if prove {
-		block := env.BlockStore.LoadBlock(height)
+		block, err := env.BlockStore.LoadBlock(ctx.Context(), height)
+		return nil, fmt.Errorf("tx (%X) not found: %w", hash, err)
 		proof = block.Data.Txs.Proof(int(index)) // XXX: overflow on 32-bit machines
 	}
 
@@ -107,7 +108,10 @@ func TxSearch(ctx *rpctypes.Context, query string, prove bool, pagePtr, perPageP
 
 		var proof types.TxProof
 		if prove {
-			block := env.BlockStore.LoadBlock(r.Height)
+			block, err := env.BlockStore.LoadBlock(ctx.Context(), r.Height)
+			if err != nil {
+				return nil, err
+			}
 			proof = block.Data.Txs.Proof(int(r.Index)) // XXX: overflow on 32-bit machines
 		}
 

--- a/state/services.go
+++ b/state/services.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"context"
+
 	"github.com/lazyledger/lazyledger-core/types"
 )
 
@@ -20,13 +22,13 @@ type BlockStore interface {
 
 	LoadBaseMeta() *types.BlockMeta
 	LoadBlockMeta(height int64) *types.BlockMeta
-	LoadBlock(height int64) *types.Block
+	LoadBlock(ctx context.Context, height int64) (*types.Block, error)
 
-	SaveBlock(block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit)
+	SaveBlock(ctx context.Context, block *types.Block, blockParts *types.PartSet, seenCommit *types.Commit) error
 
 	PruneBlocks(height int64) (uint64, error)
 
-	LoadBlockByHash(hash []byte) *types.Block
+	LoadBlockByHash(ctx context.Context, hash []byte) (*types.Block, error)
 	LoadBlockPart(height int64, index int) *types.Part
 
 	LoadBlockCommit(height int64) *types.Commit

--- a/store/mock.go
+++ b/store/mock.go
@@ -1,0 +1,21 @@
+package store
+
+import (
+	"github.com/lazyledger/lazyledger-core/ipfs"
+	dbm "github.com/lazyledger/lazyledger-core/libs/db"
+	"github.com/lazyledger/lazyledger-core/libs/db/memdb"
+	"github.com/lazyledger/lazyledger-core/libs/log"
+)
+
+// MockBlockStore returns a mocked blockstore. a nil db will result in a new in memory db
+func MockBlockStore(db dbm.DB) *BlockStore {
+	if db == nil {
+		db = memdb.NewDB()
+	}
+
+	return NewBlockStore(
+		db,
+		ipfs.MockBlockStore(),
+		log.NewNopLogger(),
+	)
+}


### PR DESCRIPTION
## Description

This PR builds off of #372 and #356 to [save](https://github.com/lazyledger/lazyledger-core/blob/c2d117634cbe3dc97313068b58c79518b0bf1ef5/store/store.go#L325-L403) and [load](https://github.com/lazyledger/lazyledger-core/blob/c2d117634cbe3dc97313068b58c79518b0bf1ef5/store/store.go#L99-L123) block data via IPFS. It should be noted that it does not completely remove the [use of block parts or the `PartSetHeader`](https://github.com/lazyledger/lazyledger-core/blob/c2d117634cbe3dc97313068b58c79518b0bf1ef5/store/store.go#L346-L353). It should also be noted that it is not yet explicit or configurable in when it retrieves data from IPFS per the request of #373.

Closes: #373

