### PR TITLE
Update tail padded shares with NMT wrapper

### DIFF
--- a/types/block.go
+++ b/types/block.go
@@ -1268,7 +1268,7 @@ func (data *Data) ComputeShares() (NamespacedShares, int) {
 		wantLen = consts.MinSharecount
 	}
 
-	tailShares := GenerateTailPaddingShares(wantLen-curLen, consts.ShareSize)
+	tailShares := TailPaddingShares(wantLen - curLen)
 
 	return append(append(append(append(
 		txShares,

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -241,7 +241,7 @@ func TestNilDataAvailabilityHeaderHashDoesntCrash(t *testing.T) {
 func TestEmptyBlockData(t *testing.T) {
 	blockData := Data{}
 	shares, _ := blockData.ComputeShares()
-	assert.Equal(t, GenerateTailPaddingShares(consts.MinSquareSize, consts.ShareSize), shares)
+	assert.Equal(t, TailPaddingShares(1), shares)
 }
 
 func TestCommit(t *testing.T) {

--- a/types/share_splitting.go
+++ b/types/share_splitting.go
@@ -110,15 +110,19 @@ func getNextChunk(rawDatas [][]byte, outerIndex int, innerIndex int, width int) 
 	return rawData, outerIndex, innerIndex, startIndex
 }
 
-func GenerateTailPaddingShares(n int, shareWidth int) NamespacedShares {
+// tail is filler for all tail padded shares
+// it is allocated once and used everywhere
+var tail = append(
+	append(make([]byte, 0, consts.ShareSize), consts.TailPaddingNamespaceID...),
+	bytes.Repeat([]byte{0}, consts.ShareSize-consts.NamespaceSize)...,
+)
+
+func TailPaddingShares(n int) NamespacedShares {
 	shares := make([]NamespacedShare, n)
 	for i := 0; i < n; i++ {
 		shares[i] = NamespacedShare{
-			Share: append(
-				append(make([]byte, 0, shareWidth), consts.TailPaddingNamespaceID...),
-				bytes.Repeat([]byte{0}, shareWidth-consts.NamespaceSize)...,
-			),
-			ID: consts.TailPaddingNamespaceID,
+			Share: tail,
+			ID:    consts.TailPaddingNamespaceID,
 		}
 	}
 	return shares

--- a/types/share_splitting.go
+++ b/types/share_splitting.go
@@ -113,7 +113,13 @@ func getNextChunk(rawDatas [][]byte, outerIndex int, innerIndex int, width int) 
 func GenerateTailPaddingShares(n int, shareWidth int) NamespacedShares {
 	shares := make([]NamespacedShare, n)
 	for i := 0; i < n; i++ {
-		shares[i] = NamespacedShare{bytes.Repeat([]byte{0}, shareWidth), consts.TailPaddingNamespaceID}
+		shares[i] = NamespacedShare{
+			Share: append(
+				append(make([]byte, 0, shareWidth), consts.TailPaddingNamespaceID...),
+				bytes.Repeat([]byte{0}, shareWidth-consts.NamespaceSize)...,
+			),
+			ID: consts.TailPaddingNamespaceID,
+		}
 	}
 	return shares
 }

--- a/types/share_splitting.go
+++ b/types/share_splitting.go
@@ -112,7 +112,7 @@ func getNextChunk(rawDatas [][]byte, outerIndex int, innerIndex int, width int) 
 
 // tail is filler for all tail padded shares
 // it is allocated once and used everywhere
-var tail = append(
+var tailPaddingShare = append(
 	append(make([]byte, 0, consts.ShareSize), consts.TailPaddingNamespaceID...),
 	bytes.Repeat([]byte{0}, consts.ShareSize-consts.NamespaceSize)...,
 )
@@ -121,7 +121,7 @@ func TailPaddingShares(n int) NamespacedShares {
 	shares := make([]NamespacedShare, n)
 	for i := 0; i < n; i++ {
 		shares[i] = NamespacedShare{
-			Share: tail,
+			Share: tailPaddingShare,
 			ID:    consts.TailPaddingNamespaceID,
 		}
 	}


### PR DESCRIPTION
While wearing a debugging hat, confusing myself, and thinking about what went wrong and what could be done better, I found a better solution for https://github.com/celestiaorg/lazyledger-core/pull/299. Also, removed one allocation in a hot path(`wrapper.Push`).

Addition: use one global tail padded share instead of generating them everytime