### PR TITLE
Add namespace id to RetrieveMessages

### DIFF
--- a/docs/lazy-adr/adr-003-application-data-retrieval.md
+++ b/docs/lazy-adr/adr-003-application-data-retrieval.md
@@ -103,6 +103,7 @@ func RetrieveStateRelevantMessages(
 // namespace ID and included in the block with the DataAvailabilityHeader dah.
 func RetrieveMessages(
     ctx context.Context,
+    nID namespace.ID,
     dah *types.DataAvailabilityHeader,
     api coreiface.CoreAPI,
 ) (Messages, error) {


### PR DESCRIPTION
`RetrieveMessages` definition lacks `nid` parameter.

