### PR TITLE
Document already made Decisions to Decouple Blockid and PartSetHeader in ADR 005

### DIFF
--- a/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
+++ b/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
@@ -23,7 +23,7 @@ While we build other better designs to experiment with, we will continue to impl
   - [X] Stop signing over the `PartSetHeader` while voting [#457](https://github.com/celestiaorg/lazyledger-core/pull/457)
   - [X] Remove the 'PartSetHeader' from the Header [#457](https://github.com/celestiaorg/lazyledger-core/pull/457)
   - [X] Remove the 'PartSetHeader' from VoteSetBits, VoteSetMaj23, and 'state.State' [#479](https://github.com/celestiaorg/lazyledger-core/pull/479)
-  - [ ] Remove the 'PartSetHeader' from other structs
+  - [ ] Remove the `PartSetHeader` from other structs
 
 
 ## Status

--- a/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
+++ b/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
@@ -28,7 +28,7 @@ While we build other better designs to experiment with, we will continue to impl
 
 ## Status
 
-{Accepted}
+Proposed
 
 ### Positive
 

--- a/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
+++ b/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
@@ -14,7 +14,7 @@ It’s worth noting that there are proposed changes to remove the `PartSetHeader
 
 ## Decision
 
-While we build other better designs to experiment with, we will continue to implement the design specified here as it is not orthogonol. https://github.com/celestiaorg/lazyledger-core/pull/434#issuecomment-869158788
+While we build other better designs to experiment with, we will continue to implement the design specified here as it is not orthogonal. https://github.com/celestiaorg/lazyledger-core/pull/434#issuecomment-869158788
 
 ## Detailed Design
 

--- a/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
+++ b/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
@@ -21,7 +21,7 @@ While we build other better designs to experiment with, we will continue to impl
 - [X] Decouple the BlockID and the PartSetHeader [#441](https://github.com/celestiaorg/lazyledger-core/pull/441)
 - [ ] Remove the BlockID from every possible struct other than the `Proposal`
   - [X] Stop signing over the `PartSetHeader` while voting [#457](https://github.com/celestiaorg/lazyledger-core/pull/457)
-  - [X] Remove the 'PartSetHeader' from the Header [#457](https://github.com/celestiaorg/lazyledger-core/pull/457)
+  - [X] Remove the `PartSetHeader` from the Header [#457](https://github.com/celestiaorg/lazyledger-core/pull/457)
   - [X] Remove the 'PartSetHeader' from VoteSetBits, VoteSetMaj23, and 'state.State' [#479](https://github.com/celestiaorg/lazyledger-core/pull/479)
   - [ ] Remove the `PartSetHeader` from other structs
 

--- a/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
+++ b/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
@@ -1,4 +1,4 @@
-# ADR 005: Decouple the 'PartSetHeader' from the 'BlockID'
+# ADR 005: Decouple the PartSetHeader from the BlockID
 
 ## Changelog
 

--- a/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
+++ b/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
@@ -18,11 +18,11 @@ While we build other better designs to experiment with, we will continue to impl
 
 ## Detailed Design
 
-- [X] Decouple the BlockID and the PartSetHeader
+- [X] Decouple the BlockID and the PartSetHeader [#441](https://github.com/celestiaorg/lazyledger-core/pull/441)
 - [ ] Remove the BlockID from every possible struct other than the `Proposal`
-  - [X] Stop signing over the `PartSetHeader` while voting 
-  - [X] Remove the `PartSetHeader` from the Header
-  - [X] Remove the `PartSetHeader` from VoteSetBits, VoteSetMaj23, and `state.State`
+  - [X] Stop signing over the `PartSetHeader` while voting [#457](https://github.com/celestiaorg/lazyledger-core/pull/457)
+  - [X] Remove the `PartSetHeader` from the Header [#457](https://github.com/celestiaorg/lazyledger-core/pull/457)
+  - [X] Remove the `PartSetHeader` from VoteSetBits, VoteSetMaj23, and `state.State` [#479](https://github.com/celestiaorg/lazyledger-core/pull/479)
   - [ ] Remove the `PartSetHeader` from other structs
 
 
@@ -42,8 +42,8 @@ While we build other better designs to experiment with, we will continue to impl
 
 ## References
 
-Alternative ADR #434
-Alternative implementation #427 and #443
-Comment that summarizes decision https://github.com/celestiaorg/lazyledger-core/pull/434#issuecomment-869158788
+Alternative ADR [#434](https://github.com/celestiaorg/lazyledger-core/pull/434)  
+Alternative implementation [#427](https://github.com/celestiaorg/lazyledger-core/pull/427) and [#443](https://github.com/celestiaorg/lazyledger-core/pull/443)  
+[Comment](https://github.com/celestiaorg/lazyledger-core/pull/434#issuecomment-869158788) that summarizes decision
 
 

--- a/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
+++ b/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
@@ -10,7 +10,7 @@ Celestia has multiple commits to the block data via the `DataHash` and the `Part
 
 ## Alternative Approaches
 
-It’s worth noting that there are proposed changes to remove the 'PartSetHeader' entirely, and instead use the already existing commitment to block data, the 'DataAvailabilityHeader', to propagate blocks in parallel during consensus. Discussions regarding the detailed differences entailed in each approach are documented in that ADR’s PR. The current direction that is described in this ADR is significantly more conservative in its approach, but it is not strictly an alternative to other designs. This is because other designs would also require removal of the 'PartSethHeader', which is a project in and of itself due to the 'BlockID' widespread usage throughout tendermint and the bugs that pop up when attempting to remove it. 
+It’s worth noting that there are proposed changes to remove the `PartSetHeader` entirely, and instead use the already existing commitment to block data, the `DataAvailabilityHeader`, to propagate blocks in parallel during consensus. Discussions regarding the detailed differences entailed in each approach are documented in that ADR’s PR. The current direction that is described in this ADR is significantly more conservative in its approach, but it is not strictly an alternative to other designs. This is because other designs would also require removal of the `PartSethHeader`, which is a project in and of itself due to the `BlockID` widespread usage throughout tendermint and the bugs that pop up when attempting to remove it. 
 
 ## Decision
 
@@ -45,4 +45,3 @@ Proposed
 Alternative ADR [#434](https://github.com/celestiaorg/lazyledger-core/pull/434)  
 Alternative implementation [#427](https://github.com/celestiaorg/lazyledger-core/pull/427) and [#443](https://github.com/celestiaorg/lazyledger-core/pull/443)  
 [Comment](https://github.com/celestiaorg/lazyledger-core/pull/434#issuecomment-869158788) that summarizes decision
-

--- a/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
+++ b/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
@@ -22,7 +22,7 @@ While we build other better designs to experiment with, we will continue to impl
 - [ ] Remove the BlockID from every possible struct other than the `Proposal`
   - [X] Stop signing over the `PartSetHeader` while voting [#457](https://github.com/celestiaorg/lazyledger-core/pull/457)
   - [X] Remove the `PartSetHeader` from the Header [#457](https://github.com/celestiaorg/lazyledger-core/pull/457)
-  - [X] Remove the 'PartSetHeader' from VoteSetBits, VoteSetMaj23, and 'state.State' [#479](https://github.com/celestiaorg/lazyledger-core/pull/479)
+  - [X] Remove the `PartSetHeader` from `VoteSetBits`, `VoteSetMaj23`, and `state.State` [#479](https://github.com/celestiaorg/lazyledger-core/pull/479)
   - [ ] Remove the `PartSetHeader` from other structs
 
 

--- a/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
+++ b/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
@@ -19,7 +19,7 @@ While we build other better designs to experiment with, we will continue to impl
 ## Detailed Design
 
 - [X] Decouple the BlockID and the PartSetHeader [#441](https://github.com/celestiaorg/lazyledger-core/pull/441)
-- [ ] Remove the BlockID from every possible struct other than the 'Proposal'
+- [ ] Remove the BlockID from every possible struct other than the `Proposal`
   - [X] Stop signing over the `PartSetHeader` while voting [#457](https://github.com/celestiaorg/lazyledger-core/pull/457)
   - [X] Remove the 'PartSetHeader' from the Header [#457](https://github.com/celestiaorg/lazyledger-core/pull/457)
   - [X] Remove the 'PartSetHeader' from VoteSetBits, VoteSetMaj23, and 'state.State' [#479](https://github.com/celestiaorg/lazyledger-core/pull/479)

--- a/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
+++ b/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
@@ -1,0 +1,49 @@
+# ADR 005: Decouple the `PartSetHeader` from the `BlockID`
+
+## Changelog
+
+- 2021-08-01: Initial Draft
+
+## Context
+
+Celestia has multiple commits to the block data via the `DataHash` and the `PartSetHeader` in the `BlockID`. As stated in the #184, we no longer need the `PartSetHeader` for this additional commitment to the block’s data. However, in the short-medium term, we are still planning on using the `PartSetHeader` to be used for block propagation during consensus. This means that we will remove the `PartSetHeader` from as many places as possible, but keep it in the `Proposal` struct.
+
+## Alternative Approaches
+
+It’s worth noting that there are proposed changes to remove the `PartSetHeader` entirely, and instead use the already existing commitment to block data, the `DataAvailabilityHeader`, to propagate blocks in parallel during consensus. Discussions regarding the detailed differences entailed in each approach are documented in that ADR’s PR. The current direction that is described in this ADR is significantly more conservative in its approach, but it is not strictly an alternative to other designs. This is because other designs would also require removal of the `PartSethHeader`, which is a project in and of itself due to the `BlockID` widespread usage throughout tendermint and the bugs that pop up when attempting to remove it. 
+
+## Decision
+
+While we build other better designs to experiment with, we will continue to implement the design specified here as it is not orthogonol. https://github.com/celestiaorg/lazyledger-core/pull/434#issuecomment-869158788
+
+## Detailed Design
+
+- [X] Decouple the BlockID and the PartSetHeader
+- [ ] Remove the BlockID from every possible struct other than the `Proposal`
+  - [X] Stop signing over the `PartSetHeader` while voting 
+  - [X] Remove the `PartSetHeader` from the Header
+  - [X] Remove the `PartSetHeader` from VoteSetBits, VoteSetMaj23, and `state.State`
+  - [ ] Remove the `PartSetHeader` from other structs
+
+
+## Status
+
+{Accepted}
+
+### Positive
+
+- Conservative and easy to implement
+- Acts as a stepping stone for other better designs
+- Allows us to use 64kb sized chunks, which are well tested
+
+### Negative
+
+- Not an ideal design as we still have to include an extra commitment to the block's data in the proposal
+
+## References
+
+Alternative ADR #434
+Alternative implementation #427 and #443
+Comment that summarizes decision https://github.com/celestiaorg/lazyledger-core/pull/434#issuecomment-869158788
+
+

--- a/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
+++ b/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
@@ -1,4 +1,4 @@
-# ADR 005: Decouple the `PartSetHeader` from the `BlockID`
+# ADR 005: Decouple the 'PartSetHeader' from the 'BlockID'
 
 ## Changelog
 
@@ -6,11 +6,11 @@
 
 ## Context
 
-Celestia has multiple commits to the block data via the `DataHash` and the `PartSetHeader` in the `BlockID`. As stated in the #184, we no longer need the `PartSetHeader` for this additional commitment to the block’s data. However, in the short-medium term, we are still planning on using the `PartSetHeader` to be used for block propagation during consensus. This means that we will remove the `PartSetHeader` from as many places as possible, but keep it in the `Proposal` struct.
+Celestia has multiple commits to the block data via the 'DataHash' and the 'PartSetHeader' in the 'BlockID'. As stated in the #184, we no longer need the 'PartSetHeader' for this additional commitment to the block’s data. However, in the short-medium term, we are still planning on using the 'PartSetHeader' to be used for block propagation during consensus. This means that we will remove the 'PartSetHeader' from as many places as possible, but keep it in the 'Proposal' struct.
 
 ## Alternative Approaches
 
-It’s worth noting that there are proposed changes to remove the `PartSetHeader` entirely, and instead use the already existing commitment to block data, the `DataAvailabilityHeader`, to propagate blocks in parallel during consensus. Discussions regarding the detailed differences entailed in each approach are documented in that ADR’s PR. The current direction that is described in this ADR is significantly more conservative in its approach, but it is not strictly an alternative to other designs. This is because other designs would also require removal of the `PartSethHeader`, which is a project in and of itself due to the `BlockID` widespread usage throughout tendermint and the bugs that pop up when attempting to remove it. 
+It’s worth noting that there are proposed changes to remove the 'PartSetHeader' entirely, and instead use the already existing commitment to block data, the 'DataAvailabilityHeader', to propagate blocks in parallel during consensus. Discussions regarding the detailed differences entailed in each approach are documented in that ADR’s PR. The current direction that is described in this ADR is significantly more conservative in its approach, but it is not strictly an alternative to other designs. This is because other designs would also require removal of the 'PartSethHeader', which is a project in and of itself due to the 'BlockID' widespread usage throughout tendermint and the bugs that pop up when attempting to remove it. 
 
 ## Decision
 
@@ -19,11 +19,11 @@ While we build other better designs to experiment with, we will continue to impl
 ## Detailed Design
 
 - [X] Decouple the BlockID and the PartSetHeader [#441](https://github.com/celestiaorg/lazyledger-core/pull/441)
-- [ ] Remove the BlockID from every possible struct other than the `Proposal`
-  - [X] Stop signing over the `PartSetHeader` while voting [#457](https://github.com/celestiaorg/lazyledger-core/pull/457)
-  - [X] Remove the `PartSetHeader` from the Header [#457](https://github.com/celestiaorg/lazyledger-core/pull/457)
-  - [X] Remove the `PartSetHeader` from VoteSetBits, VoteSetMaj23, and `state.State` [#479](https://github.com/celestiaorg/lazyledger-core/pull/479)
-  - [ ] Remove the `PartSetHeader` from other structs
+- [ ] Remove the BlockID from every possible struct other than the 'Proposal'
+  - [X] Stop signing over the 'PartSetHeader' while voting [#457](https://github.com/celestiaorg/lazyledger-core/pull/457)
+  - [X] Remove the 'PartSetHeader' from the Header [#457](https://github.com/celestiaorg/lazyledger-core/pull/457)
+  - [X] Remove the 'PartSetHeader' from VoteSetBits, VoteSetMaj23, and 'state.State' [#479](https://github.com/celestiaorg/lazyledger-core/pull/479)
+  - [ ] Remove the 'PartSetHeader' from other structs
 
 
 ## Status

--- a/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
+++ b/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-Celestia has multiple commits to the block data via the `DataHash` and the `PartSetHeader` in the `BlockID`. As stated in the [#184](https://github.com/celestiaorg/lazyledger-core/issues/184), we no longer need the `PartSetHeader` for this additional commitment to the block’s data. However, we are still planning to use the `PartSetHeader` for block propagation during consensus in the short-medium term. This means that we will remove the `PartSetHeader` from as many places as possible, but keep it in the `Proposal` struct.
+Celestia has multiple commits to the block data via the `DataHash` and the `PartSetHeader` in the `BlockID`. As stated in the [#184](https://github.com/celestiaorg/lazyledger-core/issues/184), we no longer need the `PartSetHeader` for this additional commitment to the block's data. However, we are still planning to use the `PartSetHeader` for block propagation during consensus in the short-medium term. This means that we will remove the `PartSetHeader` from as many places as possible, but keep it in the `Proposal` struct.
 
 ## Alternative Approaches
 

--- a/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
+++ b/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-Celestia has multiple commits to the block data via the 'DataHash' and the 'PartSetHeader' in the 'BlockID'. As stated in the [#184](https://github.com/celestiaorg/lazyledger-core/issues/184), we no longer need the 'PartSetHeader' for this additional commitment to the block’s data. However, in the short-medium term, we are still planning on using the 'PartSetHeader' to be used for block propagation during consensus. This means that we will remove the 'PartSetHeader' from as many places as possible, but keep it in the 'Proposal' struct.
+Celestia has multiple commits to the block data via the `DataHash` and the `PartSetHeader` in the `BlockID`. As stated in the [#184](https://github.com/celestiaorg/lazyledger-core/issues/184), we no longer need the `PartSetHeader` for this additional commitment to the block’s data. However, we are still planning to use the `PartSetHeader` for block propagation during consensus in the short-medium term. This means that we will remove the `PartSetHeader` from as many places as possible, but keep it in the `Proposal` struct.
 
 ## Alternative Approaches
 
@@ -45,5 +45,4 @@ Proposed
 Alternative ADR [#434](https://github.com/celestiaorg/lazyledger-core/pull/434)  
 Alternative implementation [#427](https://github.com/celestiaorg/lazyledger-core/pull/427) and [#443](https://github.com/celestiaorg/lazyledger-core/pull/443)  
 [Comment](https://github.com/celestiaorg/lazyledger-core/pull/434#issuecomment-869158788) that summarizes decision
-
 

--- a/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
+++ b/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-Celestia has multiple commits to the block data via the 'DataHash' and the 'PartSetHeader' in the 'BlockID'. As stated in the #184, we no longer need the 'PartSetHeader' for this additional commitment to the block’s data. However, in the short-medium term, we are still planning on using the 'PartSetHeader' to be used for block propagation during consensus. This means that we will remove the 'PartSetHeader' from as many places as possible, but keep it in the 'Proposal' struct.
+Celestia has multiple commits to the block data via the 'DataHash' and the 'PartSetHeader' in the 'BlockID'. As stated in the [#184](https://github.com/celestiaorg/lazyledger-core/issues/184), we no longer need the 'PartSetHeader' for this additional commitment to the block’s data. However, in the short-medium term, we are still planning on using the 'PartSetHeader' to be used for block propagation during consensus. This means that we will remove the 'PartSetHeader' from as many places as possible, but keep it in the 'Proposal' struct.
 
 ## Alternative Approaches
 

--- a/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
+++ b/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
@@ -10,7 +10,7 @@ Celestia has multiple commits to the block data via the `DataHash` and the `Part
 
 ## Alternative Approaches
 
-It’s worth noting that there are proposed changes to remove the `PartSetHeader` entirely, and instead use the already existing commitment to block data, the `DataAvailabilityHeader`, to propagate blocks in parallel during consensus. Discussions regarding the detailed differences entailed in each approach are documented in that ADR’s PR. The current direction that is described in this ADR is significantly more conservative in its approach, but it is not strictly an alternative to other designs. This is because other designs would also require removal of the `PartSethHeader`, which is a project in and of itself due to the `BlockID` widespread usage throughout tendermint and the bugs that pop up when attempting to remove it. 
+It’s worth noting that there are proposed changes to remove the `PartSetHeader` entirely, and instead use the already existing commitment to block data, the `DataAvailabilityHeader`, to propagate blocks in parallel during consensus. Discussions regarding the detailed differences entailed in each approach are documented in that ADR's PR. The current direction that is described in this ADR is significantly more conservative in its approach, but it is not strictly an alternative to other designs. This is because other designs would also require removal of the `PartSethHeader`, which is a project in and of itself due to the `BlockID` widespread usage throughout tendermint and the bugs that pop up when attempting to remove it. 
 
 ## Decision
 

--- a/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
+++ b/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md
@@ -20,7 +20,7 @@ While we build other better designs to experiment with, we will continue to impl
 
 - [X] Decouple the BlockID and the PartSetHeader [#441](https://github.com/celestiaorg/lazyledger-core/pull/441)
 - [ ] Remove the BlockID from every possible struct other than the 'Proposal'
-  - [X] Stop signing over the 'PartSetHeader' while voting [#457](https://github.com/celestiaorg/lazyledger-core/pull/457)
+  - [X] Stop signing over the `PartSetHeader` while voting [#457](https://github.com/celestiaorg/lazyledger-core/pull/457)
   - [X] Remove the 'PartSetHeader' from the Header [#457](https://github.com/celestiaorg/lazyledger-core/pull/457)
   - [X] Remove the 'PartSetHeader' from VoteSetBits, VoteSetMaj23, and 'state.State' [#479](https://github.com/celestiaorg/lazyledger-core/pull/479)
   - [ ] Remove the 'PartSetHeader' from other structs


### PR DESCRIPTION
## Description

This PR introduces a small ADR to document the decision to decouple the `PartSetHeader` from the `BlockID` and remove it where possible. As stated in the ADR, this design is not really an alternative to other more discussed designs, but more of a short term solution and a stepping stone to other better schemes.

[rendered](https://github.com/celestiaorg/lazyledger-core/blob/e22e3d74538c3c79b616e14eaa52e63f4f8f2fe8/docs/lazy-adr/adr-005-decouple-blockid-and-partsetheader.md)